### PR TITLE
Tool crashes when source file exists and destination file does not

### DIFF
--- a/index.js
+++ b/index.js
@@ -636,7 +636,10 @@ function _xml_parse( dom ) {
       var href = response.href[0]
       var propstat = response.propstat[0]
       var prop = response.propstat[0].prop[0]
-      var getlastmodified = response.propstat[0].prop[0].getlastmodified[0]
+      var getlastmodified = 0
+      if ('undefined' !== typeof response.propstat[0].prop[0].getlastmodified) {
+          getlastmodified = response.propstat[0].prop[0].getlastmodified[0]
+      }
       var stat = response.propstat[0].status[0]
       var resource = {}
       resource.href = href._


### PR DESCRIPTION
Sometimes source machine has a file and the destination machine (webdav supporting server) does not have it.
Because of this the following happens: response.propstat[0].prop[0].getlastmodified property becomes typeof undefined (a.k.a simply does not exists) and this causes the infamous JS error "TypeError: Cannot read property '0' of undefined".

Thus from my point of view it would be reasonable just to force this tool to upload the missing file to destination machine (server).
